### PR TITLE
removed host filesystem access, replaced with sane locations

### DIFF
--- a/com.playonlinux.PlayOnLinux4.yaml
+++ b/com.playonlinux.PlayOnLinux4.yaml
@@ -14,7 +14,12 @@ finish-args:
   - --share=ipc
   - --share=network
   - --allow=multiarch
-  - --filesystem=host:rw
+  - --filesystem=home
+  - --filesystem=/media
+  - --filesystem=/mnt
+  - --filesystem=/run/media
+  - --filesystem=/var/run/media
+  - --filesystem=/var/mnt
   - --env=__GLX_VENDOR_LIBRARY_NAME=mesa
 
 cleanup:


### PR DESCRIPTION
it should not have host access

This is not hardening, its simply all the locations media file actually are at. Its a start for easier hardening also for users

  - --filesystem=home
  - --filesystem=/media
  - --filesystem=/mnt
  - --filesystem=/run/media
  - --filesystem=/var/run/media
  - --filesystem=/var/mnt