### PR TITLE
Drop org.winehq.Wine.DLL reference

### DIFF
--- a/com.playonlinux.PlayOnLinux4.yaml
+++ b/com.playonlinux.PlayOnLinux4.yaml
@@ -29,7 +29,6 @@ inherit-extensions:
   - org.freedesktop.Platform.ffmpeg-full
   - org.freedesktop.Platform.GL32
   - org.freedesktop.Platform.VAAPI.Intel.i386
-  - org.winehq.Wine.DLLs
   - org.winehq.Wine.gecko
   - org.winehq.Wine.mono
 


### PR DESCRIPTION
This extension is broken and discontinued, see https://github.com/flathub/org.winehq.Wine/issues/154